### PR TITLE
eatery and attraction dropdowns now display relative to selected park's state

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@
                 <option selected disabled>National Parks</option>
             </select>
             <select name="attractionDropDown" id="attractionDropDown">
-                <option selected disabled>Attraction Locations</option>
+                <option selected disabled>Select a park first</option>
             </select>
             <select name="eateryDropDown" id="eateryDropDown">
-                <option selected disabled>Eateries</option>
+                <option selected disabled>Select a park first</option>
             </select>
         </div>
     </header>

--- a/scripts/data/AttractionProvider.js
+++ b/scripts/data/AttractionProvider.js
@@ -4,7 +4,7 @@ export const getAttraction = () => {
     return fetch("http://holidayroad.nss.team/bizarreries")
     .then(response => response.json())
     .then(parsedResponse => {
-       allAttractions = parsedResponse;
+        allAttractions = parsedResponse;
         return parsedResponse;
     })
 };

--- a/scripts/data/WeatherProvider.js
+++ b/scripts/data/WeatherProvider.js
@@ -6,9 +6,7 @@ export const getWeather = () => {
 
     return fetch(`http://api.openweathermap.org/data/2.5/forecast?q=Hodgenville,KY,840&units=imperial&appid=${settings.weatherKey}`)
         .then(response => response.json())
-        .then(parsedResponse => {
-            console.log(parsedResponse.list)
-
+        .then(parsedResponse => {            
             weatherForecast = parsedResponse.list;
             let filteredWeather = [];
             for (let i = 0; i < weatherForecast.length; i++) {
@@ -16,7 +14,6 @@ export const getWeather = () => {
                     filteredWeather.push(weatherForecast[i])
                 }
             }
-            console.log(filteredWeather);
             weatherForecast = filteredWeather;
             return filteredWeather;
         })

--- a/scripts/dropdowns/filterAttractions.js
+++ b/scripts/dropdowns/filterAttractions.js
@@ -1,0 +1,12 @@
+import {useAllAttractions} from '../data/AttractionProvider.js'
+
+export const filterAttractionsByState = (state) => {
+    let filteredArr = []
+    let fullArr = useAllAttractions()
+        for (const eachAttr of fullArr) {
+            if (eachAttr.state === state) {
+                filteredArr.push(eachAttr)
+            }
+        }
+        return filteredArr
+}

--- a/scripts/dropdowns/filterEateries.js
+++ b/scripts/dropdowns/filterEateries.js
@@ -1,0 +1,12 @@
+import {useAllEateries} from '../data/EateryProvider.js';
+
+export const filterEateriesByState = (state) => {
+    let filteredArr = [];
+    let fullArr = useAllEateries();
+    for (const eachEat of fullArr) {
+        if (eachEat.state === state) {
+            filteredArr.push(eachEat)
+        }
+    }
+    return filteredArr
+}

--- a/scripts/dropdowns/listAttractionsInDropDown.js
+++ b/scripts/dropdowns/listAttractionsInDropDown.js
@@ -1,20 +1,14 @@
-import {getAttraction} from '../data/AttractionProvider.js';
-
 const optionsList = (obj) => {
     return `
         <option value="${obj.id}">${obj.name}</option>
     `
 }
 
-export const listAttractionsInDropDown = () => {
+export const listAttractionsInDropDown = (arr) => {
     let dropdownHTML = '';
     const DOMSelector = document.querySelector('#attractionDropDown');
-    getAttraction()
-    .then(arr => {
-        for (const eachObj of arr) {
-            dropdownHTML += optionsList(eachObj)
-        }
-        DOMSelector.innerHTML += dropdownHTML
-    })
-
+    for (const eachObj of arr) {
+        dropdownHTML += optionsList(eachObj)
+    }
+    DOMSelector.innerHTML = '<option selected disabled>Attraction Locations</option>'+dropdownHTML
 }

--- a/scripts/dropdowns/listEateriesInDropDown.js
+++ b/scripts/dropdowns/listEateriesInDropDown.js
@@ -1,20 +1,14 @@
-import {getEateries} from '../data/EateryProvider.js';
-
 const optionsList = (obj) => {
     return `
         <option value="${obj.id}">${obj.businessName}</option>
     `
 }
 
-export const listEateriesInDropDown = () => {
+export const listEateriesInDropDown = (arr) => {
     let dropdownHTML = '';
     const DOMSelector = document.querySelector('#eateryDropDown');
-    getEateries()
-    .then(arr => {
-        for (const eachObj of arr) {
-            dropdownHTML += optionsList(eachObj)
-        }
-        DOMSelector.innerHTML += dropdownHTML
-    })
-
+    for (const eachObj of arr) {
+        dropdownHTML += optionsList(eachObj)
+    }
+    DOMSelector.innerHTML = '<option selected disabled>Eateries</option>'+dropdownHTML
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5,13 +5,14 @@ import { showWeather } from "./weather/weatherList.js"
 import { eateryList } from "./eateries/eateryList.js";
 import { getEateries } from "./data/EateryProvider.js";
 import { getAttraction } from "./data/AttractionProvider.js";
-import { useAllParks, getParks } from "./data/ParkProvider.js";
+import { getParks } from "./data/ParkProvider.js";
 import { attractionList } from "./attractions/attractionList.js";
 import { listParksInDropDown } from './dropdowns/listParkDropDown.js';
 import { listAttractionsInDropDown } from './dropdowns/listAttractionsInDropDown.js';
 import { listEateriesInDropDown } from './dropdowns/listEateriesInDropDown.js';
 import { parkObj } from './parks/parkObj.js';
-
+import { filterAttractionsByState } from './dropdowns/filterAttractions.js';
+import { filterEateriesByState } from './dropdowns/filterEateries.js';
 
 const showWeatherList = () => {
     const weatherElement = document.querySelector(".weather");
@@ -42,23 +43,24 @@ const showAttractionList = () => {
 showAttractionList();
 
 listParksInDropDown();
-listAttractionsInDropDown();
-listEateriesInDropDown();
-
 
 //////////////////////ADD EVENT LISTENERS HERE\\\\\\\\\\\\\\\\\\\\
 
-
 const mainElement = document.querySelector('body')
 
-//Get user park selection
 mainElement.addEventListener("change", event => {
     if (event.target.id === "parkDropDown") {
         const selectedParkIndex = event.target.options.selectedIndex;
-
-        renderSelectedPark(event.target.options[selectedParkIndex].value)
+        const selectedParkValue = event.target.options[selectedParkIndex].value;
+        
+        renderSelectedPark(selectedParkValue);
+        
+        showFilteredAttractions(selectedParkValue);
+        showFilteredEateries(selectedParkValue);
     }
 })
+
+//Functions for event listeners/////////////////////////////////////////
 
 const renderSelectedPark = (value) => {
     getParks()
@@ -72,9 +74,53 @@ const renderSelectedPark = (value) => {
             return filtered;
         })
         .then(arrayWithPark => {
-
             const parkPreviewElement = document.querySelector('.park');
             parkPreviewElement.innerHTML = parkObj(arrayWithPark[0])
-            console.log(arrayWithPark[0].addresses[0].city)
+            //console.log(arrayWithPark[0].addresses[0].city)
         })
+}
+
+const showFilteredAttractions = (parkCode) => {
+    getParks()
+    .then(arrOfParks => {
+        let parkObj = {};
+        for (const eachPark of arrOfParks) {
+            if (eachPark.parkCode === parkCode) {
+                parkObj = eachPark
+                break; //<<<<<<<<<<<<<<<<<<<<<<<<<This function takes in the park code of the selected park, then it gets that park as an object...
+            } //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<then it gets the state code of that object.
+        }
+        return parkObj
+    })
+    .then(obj => {
+        const stateCode = obj.addresses[0].stateCode;
+        return stateCode
+    })
+    .then(state => {
+        const filteredArr = filterAttractionsByState(state)
+        listAttractionsInDropDown(filteredArr)
+    })
+}
+
+
+const showFilteredEateries = (parkCode) => {
+    getParks()
+    .then(arrOfParks => {
+        let parkObj = {};
+        for (const eachPark of arrOfParks) {
+            if (eachPark.parkCode === parkCode) {
+                parkObj = eachPark
+                break; //<<<<<<<<<<<<<<<<<<<<<<<<<This function takes in the park code of the selected park, then it gets that park as an object...
+            } //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<then it gets the state code of that object.
+        }
+        return parkObj
+    })
+    .then(obj => {
+        const stateCode = obj.addresses[0].stateCode;
+        return stateCode
+    })
+    .then(state => {
+        const filteredArr = filterEateriesByState(state)
+        listEateriesInDropDown(filteredArr)
+    })
 }


### PR DESCRIPTION
# Description

Selecting a park is now the required first step, and choosing a park populates the eatery and attraction dropdowns only with eateries and attractions that are in the same state as the selected park.

Fixes # (issue)

Tweaked HTML for the new dropdown features to display correctly

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing Instructions

Fetch, serve, view, then play around with the dropdown menus to see how they behave.
